### PR TITLE
 [releases/6.3.z] Move to s01.oss.sonatype.org Sonatype repository (#113)

### DIFF
--- a/settings.xml
+++ b/settings.xml
@@ -10,7 +10,7 @@
             <repositories>
                 <repository>
                     <id>ossrh-nexus-repository</id>
-                    <url>https://oss.sonatype.org/content/groups/public/</url>
+                    <url>https://s01.oss.sonatype.org/content/groups/public/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>
@@ -22,7 +22,7 @@
             <pluginRepositories>
                 <pluginRepository>
                     <id>ossrh-nexus-plugin-repository</id>
-                    <url>https://oss.sonatype.org/content/groups/public/</url>
+                    <url>https://s01.oss.sonatype.org/content/groups/public/</url>
                     <releases>
                         <enabled>true</enabled>
                     </releases>


### PR DESCRIPTION
backport https://github.com/windup/windup-quickstarts/pull/113